### PR TITLE
tmux, w3m context view: Set buffer name and delete it after its work

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -389,7 +389,10 @@ bind-key M-v new-window -n video -c $HOME \; \
 # hit ':' to activate links; Tab or Esc+M to browse thru the links
 # hit Esc then Shift+M to open GUI browser; make sure external browser is set in w3m config
 # hit Q to quit without confirmation 
-bind-key u capture-pane \; save-buffer /tmp/tmux-buffer \; new-window -n "w3m" '$SHELL -c "w3m < /tmp/tmux-buffer"'
+bind-key u capture-pane -b "w3m" \; \
+	save-buffer -b "w3m" /tmp/tmux-buffer \; \
+	new-window -n "w3m" '$SHELL -c "w3m < /tmp/tmux-buffer"' \; \
+	delete-buffer -b "w3m"
 
 # urlview
 # demo video: http://www.youtube.com/watch?v=guB4WuVFhtY


### PR DESCRIPTION
URL view with w3m is really nice but actually no need to save buffer permanently. It really frustrated me in buffers list. Especially when do paste-buffer, if it is the last one.